### PR TITLE
Make CI enforce correct license banner + correct DCO sign-off in commit message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn-error.log
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ cache:
 jobs:
   include:
   - stage: lint
-    script: yarn lint
+    script:
+    - ./tools/check-signed-off.sh
+    - ./tools/check-license.py
+    - yarn lint
   - stage: build
     script: yarn prepare
   - stage: test

--- a/tools/check-license.py
+++ b/tools/check-license.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import re
+import sys
+
+LICENSE = re.compile(
+    r'((#|//|\*) Copyright .*\n'
+    r')+\s?\2\n'
+    r'\s?\2 Licensed under the Apache License, Version 2.0 \(the "License"\);\n'
+    r'\s?\2 you may not use this file except in compliance with the License.\n'
+    r'\s?\2 You may obtain a copy of the License at\n'
+    r'\s?\2\n'
+    r'\s?\2     http://www.apache.org/licenses/LICENSE-2.0\n'
+    r'\s?\2\n'
+    r'\s?\2 Unless required by applicable law or agreed to in writing, software\n'
+    r'\s?\2 distributed under the License is distributed on an "AS IS" BASIS\n'
+    r'\s?\2 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
+    r'\s?\2 See the License for the specific language governing permissions and\n'
+    r'\s?\2 limitations under the License.\n'
+)
+
+INCLUDE_DIRS = [
+    'src',
+    'tools',
+]
+
+EXCLUDE_DIRS = [
+]
+
+EXTENSIONS = [
+    '.c',
+    '.cmake',
+    '.cpp',
+    '.h',
+    '.js',
+    '.py',
+    '.S',
+    '.sh',
+    '.tcl',
+    '.ts',
+]
+
+
+def main():
+    is_ok = True
+
+    for dname in INCLUDE_DIRS:
+        for root, _, files in os.walk(dname):
+            if any(root.startswith(exclude) for exclude in EXCLUDE_DIRS):
+                continue
+            for fname in files:
+                if any(fname.endswith(ext) for ext in EXTENSIONS):
+                    fpath = os.path.join(root, fname)
+                    with open(fpath) as curr_file:
+                        if not LICENSE.search(curr_file.read()):
+                            print('%s: incorrect license' % fpath)
+                            is_ok = False
+
+    if not is_ok:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/check-signed-off.sh
+++ b/tools/check-signed-off.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage
+function print_usage
+{
+ echo "Usage: $0 [--help] [--tolerant] [--travis]"
+}
+
+function print_help
+{
+ echo "$0: Check Signed-off-by message of the latest commit"
+ echo ""
+ print_usage
+ echo ""
+ echo "Optional arguments:"
+ echo "  --help            print this help message"
+ echo "  --tolerant        check the existence of the message only but don't"
+ echo "                    require the name and email address to match the author"
+ echo "                    of the commit"
+ echo "  --travis          perform check in tolerant mode if on Travis CI and not"
+ echo "                    checking a pull request, perform strict check otherwise"
+ echo ""
+ echo "The last line of every commit message must follow the form of:"
+ echo "'JerryScript-DCO-1.0-Signed-off-by: NAME EMAIL', where NAME and EMAIL must"
+ echo "match the name and email address of the author of the commit (unless in"
+ echo "tolerant mode)."
+}
+
+# Processing command line
+TOLERANT="no"
+while [ "$#" -gt 0 ]
+do
+ if [ "$1" == "--help" ]
+ then
+  print_help
+  exit 0
+ elif [ "$1" == "--tolerant" ]
+ then
+  TOLERANT="yes"
+  shift
+ elif [ "$1" == "--travis" ]
+ then
+  if [ "$TRAVIS_PULL_REQUEST" == "" ]
+  then
+   echo -e "\e[1;33mWarning! Travis-tolerant mode requested but not running on Travis CI! \e[0m"
+  elif [ "$TRAVIS_PULL_REQUEST" == "false" ]
+  then
+   TOLERANT="yes"
+  else
+   TOLERANT="no"
+  fi
+  shift
+ else
+  print_usage
+  exit 1
+ fi
+done
+
+# Determining latest commit
+parent_hashes=(`git show -s --format=%p HEAD | head -1`)
+
+if [ "${#parent_hashes[@]}" -eq 1 ]
+then
+ commit_hash=`git show -s --format=%h HEAD | head -1`
+elif [ "${#parent_hashes[@]}" -eq 2 ]
+then
+ commit_hash=${parent_hashes[1]}
+else
+ echo "$0: cannot handle commit with ${#parent_hashes[@]} parents ${parent_hashes[@]}"
+ exit 1
+fi
+
+# Checking the last line
+actual_signed_off_by_line=`git show -s --format=%B $commit_hash | sed '/^$/d' | tr -d '\015' | tail -n 1`
+
+if [ "$TOLERANT" == "no" ]
+then
+ author_name=`git show -s --format=%an $commit_hash`
+ author_email=`git show -s --format=%ae $commit_hash`
+ required_signed_off_by_line="JerryScript-DCO-1.0-Signed-off-by: $author_name $author_email"
+
+ if [ "$actual_signed_off_by_line" != "$required_signed_off_by_line" ]
+ then
+  echo -e "\e[1;33mSigned-off-by message is incorrect. The following line should be at the end of the $commit_hash commit's message: '$required_signed_off_by_line'. \e[0m"
+  exit 1
+ fi
+else
+  echo -e "\e[1;33mWarning! The name and email address of the author of the $commit_hash commit is not checked in tolerant mode! \e[0m"
+  if echo "$actual_signed_off_by_line" | grep -q -v '^JerryScript-DCO-1.0-Signed-off-by:'
+  then
+   echo -e "\e[1;33mSigned-off-by message is incorrect. The following line should be at the end of the $commit_hash commit's message: '$required_signed_off_by_line'. \e[0m"
+   exit 1
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
Addresses #5 

I lifted the checking scripts from the main jerryscript repo and changed the list of directories in the license check script to only contain `src` and `tools` and no excludes.